### PR TITLE
Port forwards

### DIFF
--- a/lib/wemux/pair/pair_connection.rb
+++ b/lib/wemux/pair/pair_connection.rb
@@ -30,6 +30,7 @@ module Wemux
           "ssh",
           ssh_options,
           "-L #{offset_port(3000)}:localhost:3000",
+          "-L #{offset_port(4000)}:localhost:4000",
           "-p #{client_port}",
           "#{Wemux::Pair.config.pair_user}@localhost",
         ].join(" ")

--- a/lib/wemux/pair/pair_connection.rb
+++ b/lib/wemux/pair/pair_connection.rb
@@ -14,8 +14,8 @@ module Wemux
         tunnel.client_port
       end
 
-      def rails_server_port
-        3000 + port_offset
+      def offset_port(port)
+        port + port_offset
       end
 
       def ssh_options
@@ -26,7 +26,13 @@ module Wemux
       end
 
       def connect
-        system "ssh #{ssh_options} -L #{rails_server_port}:localhost:3000 -p #{client_port} #{Wemux::Pair.config.pair_user}@localhost"
+        system [
+          "ssh",
+          ssh_options,
+          "-L #{offset_port(3000)}:localhost:3000",
+          "-p #{client_port}",
+          "#{Wemux::Pair.config.pair_user}@localhost",
+        ].join(" ")
       end
     end
   end


### PR DESCRIPTION
Adds port 4000 to the forwardable ports.

I think that the ideal would be to configure these from `.pair.yml` but this is just a quick fix while I'm pairing with @gringocl.
